### PR TITLE
stop early if frame compare fails

### DIFF
--- a/Core/FrameFilter.cpp
+++ b/Core/FrameFilter.cpp
@@ -25,32 +25,14 @@ FrameFilter::FrameFilter(u8 gender, u8 ability, u8 shiny, bool skip, const QVect
 {
 }
 
-bool FrameFilter::compareFrame(const Frame &frame) const
+bool FrameFilter::compareShiny(const Frame &frame) const
 {
-    if (skip)
-    {
-        return true;
-    }
+    return skip || shiny == 255 || (shiny & frame.getShiny());
+}
 
-    if (!natures.at(frame.getNature()))
-    {
-        return false;
-    }
-
-    if (gender != 255 && gender != frame.getGender())
-    {
-        return false;
-    }
-
-    if (ability != 255 && ability != frame.getAbility())
-    {
-        return false;
-    }
-
-    if (((shiny == 1 || shiny == 2) && shiny != frame.getShiny()) || (shiny == 3 && !frame.getShiny()))
-    {
-        return false;
-    }
+bool FrameFilter::compareIVs(const Frame &frame) const
+{
+    if (skip) return true;
 
     for (u8 i = 0; i < 6; i++)
     {
@@ -60,6 +42,29 @@ bool FrameFilter::compareFrame(const Frame &frame) const
             return false;
         }
     }
-
     return true;
+}
+
+bool FrameFilter::compareAbility(const Frame &frame) const
+{
+    return skip || ability == 255 || ability == frame.getAbility();
+}
+
+bool FrameFilter::compareGender(const Frame &frame) const
+{
+    return skip || gender == 255 || gender == frame.getGender();
+}
+
+bool FrameFilter::compareNature(const Frame &frame) const
+{
+    return skip || natures.at(frame.getNature());
+}
+
+bool FrameFilter::compareFrame(const Frame &frame) const
+{
+    if (skip) return true;
+
+    return compareShiny(frame) && compareIVs(frame) && 
+           compareAbility(frame) && compareGender(frame) && 
+           compareNature(frame);
 }

--- a/Core/FrameFilter.cpp
+++ b/Core/FrameFilter.cpp
@@ -32,7 +32,10 @@ bool FrameFilter::compareShiny(const Frame &frame) const
 
 bool FrameFilter::compareIVs(const Frame &frame) const
 {
-    if (skip) return true;
+    if (skip)
+    {
+        return true;
+    }
 
     for (u8 i = 0; i < 6; i++)
     {
@@ -58,13 +61,4 @@ bool FrameFilter::compareGender(const Frame &frame) const
 bool FrameFilter::compareNature(const Frame &frame) const
 {
     return skip || natures.at(frame.getNature());
-}
-
-bool FrameFilter::compareFrame(const Frame &frame) const
-{
-    if (skip) return true;
-
-    return compareShiny(frame) && compareIVs(frame) && 
-           compareAbility(frame) && compareGender(frame) && 
-           compareNature(frame);
 }

--- a/Core/FrameFilter.hpp
+++ b/Core/FrameFilter.hpp
@@ -33,7 +33,6 @@ public:
     bool compareAbility(const Frame &frame) const;
     bool compareGender(const Frame &frame) const;
     bool compareNature(const Frame &frame) const;
-    bool compareFrame(const Frame &frame) const;
 
 private:
     QVector<u8> min;

--- a/Core/FrameFilter.hpp
+++ b/Core/FrameFilter.hpp
@@ -28,6 +28,11 @@ class FrameFilter
 public:
     FrameFilter() = default;
     FrameFilter(u8 gender, u8 ability, u8 shiny, bool skip, const QVector<u8> &min, const QVector<u8> &max, const QVector<bool> &natures);
+    bool compareShiny(const Frame &frame) const;
+    bool compareIVs(const Frame &frame) const;
+    bool compareAbility(const Frame &frame) const;
+    bool compareGender(const Frame &frame) const;
+    bool compareNature(const Frame &frame) const;
     bool compareFrame(const Frame &frame) const;
 
 private:

--- a/Core/Generator/RaidGenerator.cpp
+++ b/Core/Generator/RaidGenerator.cpp
@@ -72,10 +72,12 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
     QVector<Frame> frames;
     u16 tsv = (tid ^ sid) >> 4;
 
-    u64 baseSeed = 0x82A2B175229D6A5B;
-    seed += baseSeed * (startFrame - 1);
+    for (u32 i = 1; i < startFrame; i++)
+    {
+        seed += 0x82A2B175229D6A5B;
+    }
 
-    for (u32 frame = 0; frame < maxResults; frame++, seed += baseSeed)
+    for (u32 frame = 0; frame < maxResults; frame++, seed += 0x82A2B175229D6A5B)
     {
         XoroShiro rng(seed);
         Frame result(seed, startFrame + frame);
@@ -121,7 +123,10 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
                 pid = (high << 16) | (pid & 0xffff);
             }
         }
-        if (!filter.compareShiny(result)) continue;
+        if (!filter.compareShiny(result)) 
+        {
+            continue;
+        }
         result.setPID(pid);
 
         // Set IVs that will be 31s
@@ -143,7 +148,10 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
                 result.setIV(i, static_cast<u8>(rng.nextInt(31)));
             }
         }
-        if (!filter.compareIVs(result)) continue;
+        if (!filter.compareIVs(result))
+        {
+            continue;
+        }
 
         if (abilityType == 4) // Allow hidden ability
         {
@@ -157,7 +165,10 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
         {
             result.setAbility(abilityType);
         }
-        if (!filter.compareAbility(result)) continue;
+        if (!filter.compareAbility(result))
+        {
+            continue;
+        }
 
         // Altform, doesn't seem to have a rand call for raids
 
@@ -192,7 +203,10 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
         {
             result.setGender(2);
         }
-        if (!filter.compareGender(result)) continue;
+        if (!filter.compareGender(result))
+        {
+            continue;
+        }
 
         if (species != 849)
         {

--- a/Core/Generator/RaidGenerator.cpp
+++ b/Core/Generator/RaidGenerator.cpp
@@ -72,12 +72,10 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
     QVector<Frame> frames;
     u16 tsv = (tid ^ sid) >> 4;
 
-    for (u32 i = 1; i < startFrame; i++)
-    {
-        seed += 0x82A2B175229D6A5B;
-    }
+    u64 baseSeed = 0x82A2B175229D6A5B;
+    seed += baseSeed * (startFrame - 1);
 
-    for (u32 frame = 0; frame < maxResults; frame++, seed += 0x82A2B175229D6A5B)
+    for (u32 frame = 0; frame < maxResults; frame++, seed += baseSeed)
     {
         XoroShiro rng(seed);
         Frame result(seed, startFrame + frame);
@@ -123,6 +121,7 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
                 pid = (high << 16) | (pid & 0xffff);
             }
         }
+        if (!filter.compareShiny(result)) continue;
         result.setPID(pid);
 
         // Set IVs that will be 31s
@@ -144,6 +143,7 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
                 result.setIV(i, static_cast<u8>(rng.nextInt(31)));
             }
         }
+        if (!filter.compareIVs(result)) continue;
 
         if (abilityType == 4) // Allow hidden ability
         {
@@ -157,6 +157,7 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
         {
             result.setAbility(abilityType);
         }
+        if (!filter.compareAbility(result)) continue;
 
         // Altform, doesn't seem to have a rand call for raids
 
@@ -191,6 +192,7 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
         {
             result.setGender(2);
         }
+        if (!filter.compareGender(result)) continue;
 
         if (species != 849)
         {
@@ -201,7 +203,7 @@ QVector<Frame> RaidGenerator::generate(const FrameFilter &filter, u64 seed) cons
             result.setNature(toxtricityAmpedNatures[rng.nextInt(13, 15)]);
         }
 
-        if (filter.compareFrame(result))
+        if (filter.compareNature(result))
         {
             frames.append(result);
         }


### PR DESCRIPTION
In most use cases the shiny filter will be enabled, which means frame comparing is likely to fail when checking the shiny type. It will significantly improve performance if the frame generating loop stops here.