### PR TITLE
Fix bug with progress of SeedSearcher

### DIFF
--- a/Core/Searcher/SeedSearcher.cpp
+++ b/Core/Searcher/SeedSearcher.cpp
@@ -26,6 +26,8 @@ SeedSearcher::SeedSearcher(const QVector<Pokemon> &pokemon, const QVector<int> &
     firstResult(firstResult),
     searching(false)
 {
+    progress = 0;
+
     for (u8 i = 0; i < pokemon.size(); i++)
     {
         const auto &mon = pokemon.at(i);

--- a/Core/Searcher/SeedSearcher.cpp
+++ b/Core/Searcher/SeedSearcher.cpp
@@ -24,10 +24,9 @@ SeedSearcher::SeedSearcher(const QVector<Pokemon> &pokemon, const QVector<int> &
     pokemon(pokemon),
     ivCount(ivCount),
     firstResult(firstResult),
-    searching(false)
+    searching(false),
+    progress(0)
 {
-    progress = 0;
-
     for (u8 i = 0; i < pokemon.size(); i++)
     {
         const auto &mon = pokemon.at(i);


### PR DESCRIPTION
I noticed that the time estimation in the SeedSearcher was sometimes very unstable. This happend when I started the search, canceld it and started it again multiple times. I noticed as well that the progress bar sometimes imediately started with one percent or more.
  
After some research I found the problem. The problem is described below using some command line outputs:
```
// First click on Search

searcher = 0x8884280 // SeedCalculator, line 122

search( min = 0 , max = 357913941 ) // SeedSearcher, line 74
search( min = 357913941 , max = 715827882 ) 
search( min = 715827882 , max = 1073741823 ) 

190177 / 1073741823 // the current search progress, getProgress() / getMaxProgress()
388566 / 1073741823 
588551 / 1073741823 
787936 / 1073741823 
987846 / 1073741823 
1186445 / 1073741823 
1384691 / 1073741823 
1584336 / 1073741823 

// Cancel
// Second click on Search

searcher = 0x8884280 // same searcher object

search( min = 0 , max = 357913941 ) // starts the search again -> progress should be zero
search( min = 357913941 , max = 715827882 ) 
search( min = 715827882 , max = 1073741823 ) 

1844382 / 1073741823 // but the variable "progress" was not reset to zero
2043639 / 1073741823 
2245438 / 1073741823 
2445973 / 1073741823 
2645685 / 1073741823
```

So I simply added `progress = 0;` to the constructor of SeedSearcher and I couldn't replicate this problem again. It should now work correctly:

```
// First click on Search

searcher = 0x984e850 

193094 / 1073741823 
397623 / 1073741823 
598849 / 1073741823 

// Cancel
// Second click on Search

searcher = 0x984e850 // same object

195498 / 1073741823 // resets the progress as needed
380718 / 1073741823 
572310 / 1073741823 
```

It's not a big deal but still pretty annoying when the estimated time jumps around a lot because of that.