### PR TITLE
Changed casing for Event Data window title.

### DIFF
--- a/Forms/MainWindow.cpp
+++ b/Forms/MainWindow.cpp
@@ -404,7 +404,7 @@ void MainWindow::downloadEventData()
     }
 
     bool flag;
-    QString item = QInputDialog::getItem(this, tr("Download event data"), tr("Event"), entries, 0, false, &flag, Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+    QString item = QInputDialog::getItem(this, tr("Download Event Data"), tr("Event"), entries, 0, false, &flag, Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
     if (!flag)
     {
         return;

--- a/i18n/RaidFinder_de.ts
+++ b/i18n/RaidFinder_de.ts
@@ -708,7 +708,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation>Eventdaten herunterladen</translation>
     </message>
     <message>

--- a/i18n/RaidFinder_en.ts
+++ b/i18n/RaidFinder_en.ts
@@ -708,8 +708,8 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
-        <translation>Download event data</translation>
+        <source>Download Event Data</source>
+        <translation>Download Event Data</translation>
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="430"/>

--- a/i18n/RaidFinder_es.ts
+++ b/i18n/RaidFinder_es.ts
@@ -708,7 +708,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/RaidFinder_fr.ts
+++ b/i18n/RaidFinder_fr.ts
@@ -708,7 +708,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/RaidFinder_it.ts
+++ b/i18n/RaidFinder_it.ts
@@ -708,7 +708,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/RaidFinder_ja.ts
+++ b/i18n/RaidFinder_ja.ts
@@ -708,7 +708,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/RaidFinder_ko.ts
+++ b/i18n/RaidFinder_ko.ts
@@ -708,7 +708,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/RaidFinder_pt.ts
+++ b/i18n/RaidFinder_pt.ts
@@ -708,7 +708,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation>Baixar dados de eventos</translation>
     </message>
     <message>

--- a/i18n/RaidFinder_tw.ts
+++ b/i18n/RaidFinder_tw.ts
@@ -713,7 +713,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/RaidFinder_zh.ts
+++ b/i18n/RaidFinder_zh.ts
@@ -708,7 +708,7 @@
     </message>
     <message>
         <location filename="../Forms/MainWindow.cpp" line="407"/>
-        <source>Download event data</source>
+        <source>Download Event Data</source>
         <translation>下载活动数据</translation>
     </message>
     <message>


### PR DESCRIPTION
Changed the window title for the event data downloading tool from "Download event data" to "Download Event Data" to match up with the window titles for the other tools.