### PR TITLE
Update german translation

### DIFF
--- a/Resources/Text/de/locations_de.txt
+++ b/Resources/Text/de/locations_de.txt
@@ -30,15 +30,15 @@ Inselkettenmeer
 Fernarchipel
 Wabenmeer
 Wabeninsel
-Slippery Slope
-Frostpoint Field
-Giant's Bed
-Old Cemetery
-Snowslide Slope
-Path to the Peak
-Crown Shrine
-Giant's Foot
-Frigid Sea
-Three-Point Pass
-Ballimere Lake
-Dyna Tree Hill
+Schlitterfeld
+Frostfeld
+Bett des Giganten
+Uralter Friedhof
+Schneeschlucht
+Schneegipfelpfad
+Kronentempel
+Sohle des Giganten
+Schollenmeer
+Dreiwegpass
+Ballsee-Ufer
+Hügel des Dyna-Baums

--- a/i18n/RaidFinder_de.ts
+++ b/i18n/RaidFinder_de.ts
@@ -123,7 +123,7 @@
     <message>
         <location filename="../Forms/Tools/EncounterLookup.ui"/>
         <source>Crown Tundra</source>
-        <translation type="unfinished"></translation>
+        <translation>Kronen-Schneelande</translation>
     </message>
 </context>
 <context>
@@ -323,17 +323,17 @@
     <message>
         <location filename="../Forms/Tools/IVCalculator.ui"/>
         <source>Add Row</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeile hinzufügen</translation>
     </message>
     <message>
         <location filename="../Forms/Tools/IVCalculator.ui"/>
         <source>Delete Row</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeile löschen</translation>
     </message>
     <message>
         <location filename="../Forms/Tools/IVCalculator.ui"/>
         <source>Level</source>
-        <translation type="unfinished">Level</translation>
+        <translation>Level</translation>
     </message>
 </context>
 <context>
@@ -790,7 +790,7 @@
     <message>
         <location filename="../Forms/MainWindow.ui"/>
         <source>Crown Tundra</source>
-        <translation type="unfinished"></translation>
+        <translation>Kronen-Schneelande</translation>
     </message>
 </context>
 <context>
@@ -1177,7 +1177,7 @@
     <message>
         <location filename="../Forms/Tools/SeedCalculator.ui"/>
         <source>Crown Tundra</source>
-        <translation type="unfinished"></translation>
+        <translation>Kronen-Schneelande</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
I updated the german location names for the Crown Tundra (`locations_de.txt`) as well as the other translations (`RaidFinder_de.ts`).